### PR TITLE
allow to specify where file should be downloaded to

### DIFF
--- a/src/openiap/client.py
+++ b/src/openiap/client.py
@@ -108,9 +108,9 @@ class Client():
         self.jwt = result.jwt
         self.user = result.user
         return result.user
-    async def DownloadFile(self, Id:str=None, Filename:str=None):
-        #: Download a file from openflow. Id is the id of the file, Filename is the name of the file to save it to.
-        result = await protowrap.DownloadFile(self, Id, Filename)
+    async def DownloadFile(self, Id:str=None, Filename:str=None, OutPath: str=None):
+        #: Download a file from openflow. Id is the id of the file, Filename is the name of the file to save it to, OutPath is the path where the file should be saved.
+        result = await protowrap.DownloadFile(self, Id, Filename, OutPath)
         return result
     async def GetElement(self, xpath:str):
         request = base_pb2.Envelope(command="getelement")

--- a/src/openiap/protowrap.py
+++ b/src/openiap/protowrap.py
@@ -225,15 +225,19 @@ class protowrap():
             yield protowrap.seed
             protowrap.seed += 1
     @staticmethod
-    async def DownloadFile(client, Id:str=None, Filename:str=None):
+    async def DownloadFile(client, Id: str = None, Filename: str = None, OutPath: str = None):
         request = base_pb2.Envelope(command="download")
         request.data.Pack(base_pb2.DownloadRequest(filename=Filename,id=Id))
         rid = str(next(protowrap.uniqueid()))
         request.id = rid
         protowrap.SetStream(rid)
-        result:base_pb2.DownloadResponse = await protowrap.RPC(client, request, rid)
-        if(result.filename != None and result.filename != ""):
-            with open(result.filename, "wb") as out_file:
+        result: base_pb2.DownloadResponse = await protowrap.RPC(client, request, rid)
+        if (result.filename != None and result.filename != ""):
+            if OutPath != None and OutPath != "":
+                Path = OutPath + "/" + result.filename
+            else:
+                Path = result.filename
+            with open(Path, "wb") as out_file:
                 out_file.write(protowrap.streams[rid])
         protowrap.streams.pop(rid, None)
         return result


### PR DESCRIPTION
Allow control of where downloaded files should be put. If nothing is specified it should work as it did before.